### PR TITLE
메인 페이지에서 사용자 관심사를 기반으로 한 모임 리스트 조회(추천)

### DIFF
--- a/src/main/java/org/rf/rfserver/domain/Party.java
+++ b/src/main/java/org/rf/rfserver/domain/Party.java
@@ -33,6 +33,9 @@ public class Party extends BaseEntity{
     @Enumerated(EnumType.STRING)
     private List<Rule> rules;
     @Enumerated(EnumType.STRING)
+    @ElementCollection(targetClass=Interest.class)
+    @CollectionTable(name="party_interest")
+    @Column(name="interest")
     private List<Interest> interests;
     @OneToMany(mappedBy = "party")
     private List<Schedule> schedules;

--- a/src/main/java/org/rf/rfserver/domain/Party.java
+++ b/src/main/java/org/rf/rfserver/domain/Party.java
@@ -35,7 +35,6 @@ public class Party extends BaseEntity{
     @Enumerated(EnumType.STRING)
     @ElementCollection(targetClass=Interest.class)
     @CollectionTable(name="party_interest")
-    @Column(name="interest")
     private List<Interest> interests;
     @OneToMany(mappedBy = "party")
     private List<Schedule> schedules;

--- a/src/main/java/org/rf/rfserver/party/controller/PartyController.java
+++ b/src/main/java/org/rf/rfserver/party/controller/PartyController.java
@@ -5,10 +5,7 @@ import org.rf.rfserver.config.BaseException;
 import org.rf.rfserver.config.BaseResponse;
 
 
-import org.rf.rfserver.party.dto.party.DeletePartyRes;
-import org.rf.rfserver.party.dto.party.GetPartyRes;
-import org.rf.rfserver.party.dto.party.PostPartyReq;
-import org.rf.rfserver.party.dto.party.PostPartyRes;
+import org.rf.rfserver.party.dto.party.*;
 import org.rf.rfserver.party.dto.partyjoin.PostApproveJoinRes;
 import org.rf.rfserver.party.dto.partyjoin.PostDenyJoinRes;
 import org.rf.rfserver.party.dto.partyjoinapply.PostJoinApplicationReq;
@@ -121,4 +118,15 @@ public class PartyController {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+    // 사용자 관심사 기반 모임 목록 불러오기
+    @GetMapping("/user/{userId}/interests")
+    public BaseResponse<PageDto<List<GetInterestPartyRes>>> getPartiesByUserInterests(@PathVariable("userId") Long userId, Pageable pageable) {
+        try {
+            return new BaseResponse<>(partyService.getPartiesByUserInterests(userId, pageable));
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
 }

--- a/src/main/java/org/rf/rfserver/party/dto/party/GetInterestPartyRes.java
+++ b/src/main/java/org/rf/rfserver/party/dto/party/GetInterestPartyRes.java
@@ -1,0 +1,35 @@
+package org.rf.rfserver.party.dto.party;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.rf.rfserver.constant.Interest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+
+public class GetInterestPartyRes {
+    private Long id;
+    private String name;
+    private String content;
+    private String imageFilePath;
+    private LocalDateTime createdDate;
+    private int memberCount;
+    private Long ownerId;
+    private List<Interest> interests;
+
+
+    @Builder
+    public GetInterestPartyRes(Long id, String name, String content, String imageFilePath,
+                       LocalDateTime createdDate, int memberCount, Long ownerId, List<Interest> interests) {
+        this.id = id;
+        this.name = name;
+        this.content = content;
+        this.imageFilePath = imageFilePath;
+        this.createdDate = createdDate;
+        this.memberCount = memberCount;
+        this.ownerId = ownerId;
+        this.interests = interests;
+    }
+}

--- a/src/main/java/org/rf/rfserver/party/dto/party/PostPartyReq.java
+++ b/src/main/java/org/rf/rfserver/party/dto/party/PostPartyReq.java
@@ -3,7 +3,6 @@ package org.rf.rfserver.party.dto.party;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.rf.rfserver.constant.*;
 
 import java.util.List;

--- a/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
+++ b/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
@@ -14,9 +14,12 @@ public interface PartyRepository extends JpaRepository<Party, Long>, JpaSpecific
    @Query("SELECT p FROM Party p WHERE p.id NOT IN (SELECT bp.blockedParty.id FROM BlockParty bp WHERE bp.blockerUser.id = ?1)")
    Page<Party> findNonBlockedPartiesByUserId(Long userId, Pageable pageable);
 
+   // 사용자 관심사 기반 모임 목록 불러오기 (차단한 모임 빼고)
    @Query("SELECT p FROM Party p JOIN p.interests i " +
            "WHERE i IN :userInterests AND p.id NOT IN (" +
            "SELECT up.party.id FROM UserParty up WHERE up.user.id = :userId" +
+           ") AND p.id NOT IN (" +
+           "SELECT bp.blockedParty.id FROM BlockParty bp WHERE bp.blockerUser.id = :userId" +
            ")")
    Page<Party> findPartiesByInterestsAndNotJoinedByUser(List<Interest> userInterests, Long userId, Pageable pageable);
 

--- a/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
+++ b/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
@@ -14,13 +14,13 @@ public interface PartyRepository extends JpaRepository<Party, Long>, JpaSpecific
    @Query("SELECT p FROM Party p WHERE p.id NOT IN (SELECT bp.blockedParty.id FROM BlockParty bp WHERE bp.blockerUser.id = ?1)")
    Page<Party> findNonBlockedPartiesByUserId(Long userId, Pageable pageable);
 
-   // 사용자 관심사 기반 모임 목록 불러오기 (차단한 모임 빼고)
+   // 사용자 관심사 기반 모임 목록 불러오기 (가입한 모임, 차단한 모임 제외)
    @Query("SELECT p FROM Party p JOIN p.interests i " +
            "WHERE i IN :userInterests AND p.id NOT IN (" +
            "SELECT up.party.id FROM UserParty up WHERE up.user.id = :userId" +
            ") AND p.id NOT IN (" +
            "SELECT bp.blockedParty.id FROM BlockParty bp WHERE bp.blockerUser.id = :userId" +
            ")")
-   Page<Party> findPartiesByInterestsAndNotJoinedByUser(List<Interest> userInterests, Long userId, Pageable pageable);
+   Page<Party> findInterestParties(List<Interest> userInterests, Long userId, Pageable pageable);
 
 }

--- a/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
+++ b/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
@@ -1,5 +1,6 @@
 package org.rf.rfserver.party.repository;
 
+import org.rf.rfserver.constant.Interest;
 import org.rf.rfserver.domain.Party;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,8 +8,16 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface PartyRepository extends JpaRepository<Party, Long>, JpaSpecificationExecutor<Party> {
    @Query("SELECT p FROM Party p WHERE p.id NOT IN (SELECT bp.blockedParty.id FROM BlockParty bp WHERE bp.blockerUser.id = ?1)")
    Page<Party> findNonBlockedPartiesByUserId(Long userId, Pageable pageable);
+
+   @Query("SELECT p FROM Party p JOIN p.interests i " +
+           "WHERE i IN :userInterests AND p.id NOT IN (" +
+           "SELECT up.party.id FROM UserParty up WHERE up.user.id = :userId" +
+           ")")
+   Page<Party> findPartiesByInterestsAndNotJoinedByUser(List<Interest> userInterests, Long userId, Pageable pageable);
 
 }

--- a/src/main/java/org/rf/rfserver/party/service/PartyService.java
+++ b/src/main/java/org/rf/rfserver/party/service/PartyService.java
@@ -278,13 +278,13 @@ public class PartyService {
     }
 
 
-    // 사용자 관심사 기반 모임 목록 불러오기
+    // 사용자 관심사 기반 모임 목록 불러오기 (가입한 모임, 차단한 모임 제외)
     public PageDto<List<GetInterestPartyRes>> getPartiesByUserInterests(Long userId, Pageable pageable) throws BaseException {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
 
         List<Interest> interests = user.getUserInterests();
-        Page<Party> parties = partyRepository.findPartiesByInterestsAndNotJoinedByUser(interests, userId, pageable);
+        Page<Party> parties = partyRepository.findInterestParties(interests, userId, pageable);
         System.out.println(parties);
 
         return new PageDto<>(parties.getNumber(), parties.getTotalPages(), parties.stream()

--- a/src/main/java/org/rf/rfserver/party/service/PartyService.java
+++ b/src/main/java/org/rf/rfserver/party/service/PartyService.java
@@ -4,11 +4,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.rf.rfserver.config.BaseException;
 import org.rf.rfserver.config.s3.S3Uploader;
+import org.rf.rfserver.constant.Interest;
 import org.rf.rfserver.domain.*;
-import org.rf.rfserver.party.dto.party.DeletePartyRes;
-import org.rf.rfserver.party.dto.party.GetPartyRes;
-import org.rf.rfserver.party.dto.party.PostPartyReq;
-import org.rf.rfserver.party.dto.party.PostPartyRes;
+import org.rf.rfserver.party.dto.party.*;
 import org.rf.rfserver.party.dto.partyjoin.PostApproveJoinRes;
 import org.rf.rfserver.party.dto.partyjoin.PostDenyJoinRes;
 import org.rf.rfserver.party.dto.partyjoinapply.PostJoinApplicationReq;
@@ -275,6 +273,28 @@ public class PartyService {
                         .ownerId(userParty.getParty().getOwnerId())
                         //.users(userParty.getParty().getUsers())
                         .schedules(userParty.getParty().getSchedules())
+                        .build())
+                .collect(Collectors.toList()));
+    }
+
+
+    // 사용자 관심사 기반 모임 목록 불러오기
+    public PageDto<List<GetInterestPartyRes>> getPartiesByUserInterests(Long userId, Pageable pageable) throws BaseException {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+
+        List<Interest> interests = user.getUserInterests();
+        Page<Party> parties = partyRepository.findPartiesByInterestsAndNotJoinedByUser(interests, userId, pageable);
+        System.out.println(parties);
+
+        return new PageDto<>(parties.getNumber(), parties.getTotalPages(), parties.stream()
+                .map(party -> GetInterestPartyRes.builder()
+                        .id(party.getId())
+                        .name(party.getName())
+                        .content(party.getContent())
+                        .imageFilePath(party.getImageFilePath())
+                        .memberCount(party.getMemberCount())
+                        .ownerId(party.getOwnerId())
                         .build())
                 .collect(Collectors.toList()));
     }

--- a/src/main/java/org/rf/rfserver/party/service/PartyService.java
+++ b/src/main/java/org/rf/rfserver/party/service/PartyService.java
@@ -276,8 +276,6 @@ public class PartyService {
                         .build())
                 .collect(Collectors.toList()));
     }
-
-
     // 사용자 관심사 기반 모임 목록 불러오기 (가입한 모임, 차단한 모임 제외)
     public PageDto<List<GetInterestPartyRes>> getPartiesByUserInterests(Long userId, Pageable pageable) throws BaseException {
         User user = userRepository.findById(userId)
@@ -285,7 +283,6 @@ public class PartyService {
 
         List<Interest> interests = user.getUserInterests();
         Page<Party> parties = partyRepository.findInterestParties(interests, userId, pageable);
-        System.out.println(parties);
 
         return new PageDto<>(parties.getNumber(), parties.getTotalPages(), parties.stream()
                 .map(party -> GetInterestPartyRes.builder()


### PR DESCRIPTION
## 사용자 관심사를 기반으로 한 모임 리스트 조회(추천)
- 사용자가 가입한 모임 제외
- 사용자가 차단한 모임 제외
- 사용자 관심사와 모임 관심사에 일치하는 관심사가 적어도 하나라도 있을 경우, 모임을 불러옴

## 사용 예시
- 사용자 A가 "FOOD" 와 "KPOP"이면, 사용자 A는 메인 페이지에서 **("FOOD"를 관심사로 가지고 있는 모임 + "KPOP"을 관심사로 가지고 있는 모임 - A가 가입한 모임 - A가 차단한 모임)** 목록을 볼 수 있다. 