### PR TITLE
같은 대학교 내의 모임만 조회 추가

### DIFF
--- a/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
+++ b/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface PartyRepository extends JpaRepository<Party, Long>, JpaSpecificationExecutor<Party> {
+   // 모임 불러오기 (차단 제외 / 같은 대학교 유저가 생성한 모임만 조회 가능)
    @Query("SELECT p FROM Party p " +
            "JOIN User u ON p.ownerId = u.id " +
            "WHERE u.university IN " +

--- a/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
+++ b/src/main/java/org/rf/rfserver/party/repository/PartyRepository.java
@@ -7,20 +7,30 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PartyRepository extends JpaRepository<Party, Long>, JpaSpecificationExecutor<Party> {
-   @Query("SELECT p FROM Party p WHERE p.id NOT IN (SELECT bp.blockedParty.id FROM BlockParty bp WHERE bp.blockerUser.id = ?1)")
-   Page<Party> findNonBlockedPartiesByUserId(Long userId, Pageable pageable);
+   @Query("SELECT p FROM Party p " +
+           "JOIN User u ON p.ownerId = u.id " +
+           "WHERE u.university IN " +
+           "(SELECT owner.university FROM User owner WHERE owner.id = :userId) " +
+           "AND p.id NOT IN " +
+           "(SELECT bp.blockedParty.id FROM BlockParty bp WHERE bp.blockerUser.id = :userId)")
+   Page<Party> findNonBlockedPartiesByUserId(@Param("userId") Long userId, Pageable pageable);
 
-   // 사용자 관심사 기반 모임 목록 불러오기 (가입한 모임, 차단한 모임 제외)
-   @Query("SELECT p FROM Party p JOIN p.interests i " +
-           "WHERE i IN :userInterests AND p.id NOT IN (" +
+   // 사용자 관심사 기반 모임 목록 불러오기 (가입한 모임, 차단한 모임 제외 / 같은 대학교 유저가 생성한 모임만 조회 가능)
+   @Query("SELECT p FROM Party p " +
+           "JOIN User u ON p.ownerId = u.id JOIN p.interests i " +
+           "WHERE u.university IN " +
+           "(SELECT owner.university FROM User owner WHERE owner.id = :userId) " +
+           "AND i IN :userInterests " +
+           "AND p.id NOT IN (" +
            "SELECT up.party.id FROM UserParty up WHERE up.user.id = :userId" +
-           ") AND p.id NOT IN (" +
+           ") " +
+           "AND p.id NOT IN (" +
            "SELECT bp.blockedParty.id FROM BlockParty bp WHERE bp.blockerUser.id = :userId" +
            ")")
    Page<Party> findInterestParties(List<Interest> userInterests, Long userId, Pageable pageable);
-
 }


### PR DESCRIPTION
### 같은 대학교 내의 모임만 조회할 수 있도록 쿼리 수정
- 모임 불러오기 (차단한 모임 제외 / 같은 대학교 유저가 생성한 모임만 조회 가능)
- 사용자 관심사 기반 모임 목록 불러오기 (가입한 모임, 차단한 모임 제외 / 같은 대학교 유저가 생성한 모임만 조회 가능)