### PR TITLE
feat: [#131]  Security 적용

### DIFF
--- a/src/main/java/org/rf/rfserver/config/WebSecurityConfig.java
+++ b/src/main/java/org/rf/rfserver/config/WebSecurityConfig.java
@@ -32,8 +32,8 @@ public class WebSecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests ->
-                        requests.requestMatchers("/", "/swagger-ui/**", "/user/**", "/party/**"
-                                        , "/mail/**", "/schedule/**", "/report/**","/chat/**", "/block/**",
+                        requests.requestMatchers("/", "/user/login", "/chat/**", "/user", "/user/idCheck/**", "/user/nicknameCheck/**" ,
+                                        "/user/findId", "/user/resetPassword",
                                         "/token", "/enums", "/apns/**", "/ws/**").permitAll() // requestMatchers의 인자로 전달된 url은 모두에게 허용
                                 .anyRequest().authenticated() // 그 외의 모든 요청은 인증 필요
                 )

--- a/src/main/java/org/rf/rfserver/constant/RfRule.java
+++ b/src/main/java/org/rf/rfserver/constant/RfRule.java
@@ -2,6 +2,6 @@ package org.rf.rfserver.constant;
 
 public class RfRule {
     public static final int MAX_PARTY_NUMBER = 5;
-    public static final int ACCESS_TOKEN_EXPIRATION = 2;
+    public static final int ACCESS_TOKEN_EXPIRATION = 70;
     public static final int REFRESH_TOKEN_EXPIRATION = 7;
 }

--- a/src/main/java/org/rf/rfserver/user/service/UserService.java
+++ b/src/main/java/org/rf/rfserver/user/service/UserService.java
@@ -223,7 +223,7 @@ public class UserService {
         User user = userRepository.findByLoginId(loginReq.getLoginId())
                 .filter(it -> bCryptPasswordEncoder.matches(loginReq.getPassword(), it.getPassword()))	// 암호화된 비밀번호와 비교하도록 수정
                 .orElseThrow(() -> new BaseException(INVALID_LOGIN_IR_OR_PASSWORD));
-        String accessToken = tokenProvider.generateToken(user, Duration.ofHours(ACCESS_TOKEN_EXPIRATION));
+        String accessToken = tokenProvider.generateToken(user, Duration.ofDays(ACCESS_TOKEN_EXPIRATION));
         String refreshToken = tokenProvider.generateToken(user, Duration.ofDays(REFRESH_TOKEN_EXPIRATION));
         refreshTokenService.saveRefreshToken(user.getId(), refreshToken);
         user.setDeviceToken(loginReq.getDeviceToken());


### PR DESCRIPTION
## 작업 내용
- API에 Security를 적용했습니다
## 상세 내용
- login, 회원 생성, 닉네임 체크, 비밀번호 초기화 등 requestMatchers에 있는 url들 이외에는 Token을 넣어야 동작합니다
- enums, apns, ws등 개발이 진행중인 것들에 대해서는 아직 적용하지 않았으나 말씀 주시면 적용하겠습니다
- 개발을 위해 Acceess Token 기한을 늘렸기에 merge된 후 공유해드리는 토큰을 70일동안은 사용하실 수 있습니다 
## 관련 이슈
- [이슈 트래커]: #131 )
