### PR TITLE
유저별 일정 조회 파라미터 포맷 수정

### DIFF
--- a/src/main/java/org/rf/rfserver/schedule/controller/ScheduleController.java
+++ b/src/main/java/org/rf/rfserver/schedule/controller/ScheduleController.java
@@ -46,13 +46,13 @@ public class ScheduleController {
     /**
      * 유저 일정 조회
      * @param userId
-     * @param getScheduleReq
+     * @param year, month
      * @return List[GetScheduleRes]
      **/
     @GetMapping("/user/{userId}")
-    public BaseResponse<List<GetScheduleRes>> getScheduleByUser(@PathVariable ("userId") Long userId, @RequestBody GetScheduleReq getScheduleReq){
+    public BaseResponse<List<GetScheduleRes>> getScheduleByUser(@PathVariable ("userId") Long userId, @RequestParam ("year") int year, @RequestParam ("month") int month){
         try{
-            return new BaseResponse<>(scheduleService.getScheduleByUser(userId, getScheduleReq));
+            return new BaseResponse<>(scheduleService.getScheduleByUser(userId, year, month));
         } catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/org/rf/rfserver/schedule/service/ScheduleService.java
+++ b/src/main/java/org/rf/rfserver/schedule/service/ScheduleService.java
@@ -78,18 +78,14 @@ public class ScheduleService {
     /**
      * 해당 유저의 일정 조회(월별 조회)
      * @param userId
-     * @param getScheduleReq
+     * @param year, month
      * @return List[GetScheduleRes]
      * @throws BaseException
      */
-    public List<GetScheduleRes> getScheduleByUser(Long userId, GetScheduleReq getScheduleReq) throws BaseException{
+    public List<GetScheduleRes> getScheduleByUser(Long userId, int year, int month) throws BaseException{
         //해당 유저가 존재하는지 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
-
-        //사용자가 조회하고자 하는 연도와 달의 정보를 가져옴
-        int year = getScheduleReq.getYear();
-        int month = getScheduleReq.getMonth();
 
         //월별 조회를 위한 LocalDateTime 변수 생성
         LocalDateTime startDate = LocalDateTime.of(year, month, 1,0,0,0);

--- a/src/main/java/org/rf/rfserver/schedule/service/ScheduleService.java
+++ b/src/main/java/org/rf/rfserver/schedule/service/ScheduleService.java
@@ -87,24 +87,28 @@ public class ScheduleService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(USER_NOT_FOUND));
 
-        //월별 조회를 위한 LocalDateTime 변수 생성
-        LocalDateTime startDate = LocalDateTime.of(year, month, 1,0,0,0);
-        LocalDateTime endDate = startDate.with(TemporalAdjusters.lastDayOfMonth());
+        try {
+            //월별 조회를 위한 LocalDateTime 변수 생성
+            LocalDateTime startDate = LocalDateTime.of(year, month, 1, 0, 0, 0);
+            LocalDateTime endDate = startDate.with(TemporalAdjusters.lastDayOfMonth());
 
-        //유저가 가입한 모임 목록을 가져옴
-        List<UserParty> userParties = userPartyRepository.findByUser(user);
+            //유저가 가입한 모임 목록을 가져옴
+            List<UserParty> userParties = userPartyRepository.findByUser(user);
 
-        //userParties에서 모임 정보만 리스트로 가져옴
-        List<Party> parties = userParties.stream()
+            //userParties에서 모임 정보만 리스트로 가져옴
+            List<Party> parties = userParties.stream()
                 .map(UserParty::getParty)
                 .collect(Collectors.toList());
 
-        //모임별 스케줄을 불러옴
-        List<Schedule> schedules = scheduleRepository.findByParties(parties, startDate, endDate);
+            //모임별 스케줄을 불러옴
+            List<Schedule> schedules = scheduleRepository.findByParties(parties, startDate, endDate);
 
-        return schedules.stream()
-                .map(GetScheduleRes::new)
-                .collect(Collectors.toList());
+            return schedules.stream()
+                    .map(GetScheduleRes::new)
+                    .collect(Collectors.toList());
+        } catch (Exception e){
+            throw new BaseException(DATABASE_ERROR);
+        }
     }
 
     /**


### PR DESCRIPTION
## 작업 내용
- 유저별 일정 조회 시 사용하는 파라미터의 포맷을 변경했습니다.
## 상세 내용
- Requestbody 방식에서 RequestParam(query string)을 사용하도록 변경했습니다.
- GET 요청에서는 Requestbody를 못쓴다고 하더라고요...? 왜 못쓰는걸까요 흠냐 공부해보겠습니다
## 관련 이슈
- 프론트에서 수정 요청 들어온거라 빠르게 반영하는 게 좋을 것 같습니다
- [이슈 트래커] : #148 
